### PR TITLE
Use string instread of symbols in zookeeper node cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ depends 'clickhouse'
     service_name 'clickhouse-server-test'
     # This attribute automatically generates Zookeeper config 'zookeeper-servers.xml'
     # To disable automatic generation set zookeeper_config_install to false
-    zookeeper_config_nodes [{host: 'localhost', port: 2181}]
+    zookeeper_config_nodes [{'host' => 'localhost', 'port' => 2181}]
   end
 
   clickhouse_macros_config 'clickhouse server macros config' do
@@ -145,7 +145,7 @@ Please note that when using `notifies` or `subscribes`, the resource to referenc
 - `config` - given configuration of `config.xml`, default is `node['clickhouse']['server']['config']`
 - `users` - given configuration of `config.xml`, `users.xml` include, default is `node['clickhouse']['server']['users']`
 - `zookeeper_config_install` - whether to install Zookeeper config under conf.d
-- `zookeeper_config_nodes` - Zookeeper nodes in format of `[{host: 'localhost', port: 2181}]`
+- `zookeeper_config_nodes` - Zookeeper nodes in format of `[{'host' => 'localhost', 'port' => 2181}]`
 - `service_name` - defaults to `clickhouse-server`
 - `service_unit_after` - systemd start unit after, default is 'network.target'
 - `service_timeout_sec` - systemd timeout sec, default is 5
@@ -205,7 +205,7 @@ The `:create` action zookeeper file installation.
 clickhouse_zookeeper_config 'custom instance' do
   service_name 'clickhouse-server-custom'
   nodes [
-    { host: '127.0.0.1', port: 2181 }
+    { 'host' => '127.0.0.1', 'port' => 2181 }
   ]
 end
 ```
@@ -219,7 +219,7 @@ Please note that when using `notifies` or `subscribes`, the resource to referenc
 - `config_dir` - configuration namespace directory, default is /etc/clickhouse-server/{custom instance}
 - `service_name` - defaults to `clickhouse-server`
 - `config_name` - defaults to `zookeeper`
-- `nodes` - expects Array of Hash 'es, e.g.: `[{index: 1, host: 'localhost', port: 2181}]`
+- `nodes` - expects Array of Hash 'es, e.g.: `[{index: 1, 'host' => 'localhost', 'port' => 2181}]`
 - `template_cookbook` - template cookbook source, defaults to `node['clickhouse']['server']['zookeeper']['cookbook']`
 - `template_source` - template cookbook source, defaults to `zookeeper.xml.erb`
 

--- a/libraries/clickhouse_server_service.rb
+++ b/libraries/clickhouse_server_service.rb
@@ -38,7 +38,7 @@ class Chef
         default: lazy { node['clickhouse']['server']['users'] }
       )
       attribute(:zookeeper_config_install, kind_of: [TrueClass, FalseClass], default: true)
-      attribute(:zookeeper_config_nodes, kind_of: Array, default: lazy { raise "Provide Zookeeper hosts e.g.: [{host: 'localhost', port: 2181}]" })
+      attribute(:zookeeper_config_nodes, kind_of: Array, default: lazy { raise "Provide Zookeeper hosts e.g.: [{'host' => 'localhost', 'port' => 2181}]" })
 
       # Service
       attribute(:service_name, kind_of: String, default: 'clickhouse-server')

--- a/libraries/clickhouse_zookeeper_config.rb
+++ b/libraries/clickhouse_zookeeper_config.rb
@@ -7,7 +7,7 @@ class Chef
       provides(:clickhouse_zookeeper_config)
 
       # Must be array of hashes, e.g.:
-      # [{index: 1, host: 'localhost', port: 2181}]
+      # [{index: 1, 'host' => 'localhost', 'port' => 2181}]
       # index: key is optional
       attribute(:nodes, kind_of: Array, default: lazy {
         raise "`nodes` attribute can't be empty"
@@ -42,9 +42,9 @@ class Chef
         end
         nodes.each do |node|
           raise_error_msg "#{node} must be hash" unless node.is_a?(Hash)
-          raise_error_msg "#{node} missing key :host" unless node[:host]
-          raise_error_msg "#{node} missing key :port" unless node[:port]
-          raise_error_msg "#{node} key :port must be Integer" unless node[:port].is_a?(Integer)
+          raise_error_msg "#{node} missing key 'host'" unless node['host']
+          raise_error_msg "#{node} missing key 'port'" unless node['port']
+          raise_error_msg "#{node} key 'port' must be Integer" unless node['port'].is_a?(Integer)
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures chef-clickhouse'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-clickhouse/issues'
 source_url 'https://github.com/vinted/chef-clickhouse'
-version '0.7.0'
+version '0.8.0'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'redhat'

--- a/templates/default/zookeeper.xml.erb
+++ b/templates/default/zookeeper.xml.erb
@@ -2,8 +2,8 @@
     <zookeeper>
         <% @nodes.each_with_index do |no, i| %>
           <node index="<%= no[:index] || i %>">
-              <host><%= no[:host] %></host>
-              <port><%= no[:port] %></port>
+              <host><%= no['host'] %></host>
+              <port><%= no['port'] %></port>
           </node>
         <% end %>
     </zookeeper>

--- a/test/integration/cookbooks/test-clickhouse/recipes/test_clickhouse_server.rb
+++ b/test/integration/cookbooks/test-clickhouse/recipes/test_clickhouse_server.rb
@@ -1,4 +1,4 @@
 clickhouse_server_service 'clickhouse server instance' do
   service_name 'clickhouse-server-test'
-  zookeeper_config_nodes [{host: 'localhost', port: 2181}]
+  zookeeper_config_nodes [{'host' => 'localhost', 'port' => 2181}]
 end

--- a/test/integration/cookbooks/test-clickhouse/recipes/test_zookeeper_config.rb
+++ b/test/integration/cookbooks/test-clickhouse/recipes/test_zookeeper_config.rb
@@ -2,6 +2,6 @@ clickhouse_zookeeper_config 'clickhouse server zookeeper config' do
   service_name 'clickhouse-server-test'
   config_name 'kitchen_custom_zookeeper'
   nodes [
-    { host: '127.0.0.1', port: 2181 }
+    { 'host' => '127.0.0.1', 'port' => 2181 }
   ]
 end


### PR DESCRIPTION
This way we will be able to use chef `search` to find required nodes.